### PR TITLE
Remove node modules folder from CLI path

### DIFF
--- a/handlers/sequelizeCliHandler.js
+++ b/handlers/sequelizeCliHandler.js
@@ -7,7 +7,7 @@ class SequelizeCliHandler {
 
   createMigration(name) {
     const cmdOut = childProcess.execSync(
-      `node_modules/.bin/sequelize migration:create --name ${name}`
+      `sequelize migration:create --name ${name}`
     );
     const output = Buffer.from(cmdOut, "base64").toString();
     this.serverless.cli.log(output);


### PR DESCRIPTION
I use Yarn workspaces in my project and having the `node_modules/.bin` folder explicitly defined in the exec path causes the plugin to error. Removing it allows the plugin to use the bin local to the project, regardless of where it might be located.

In my specific case, I have a workspace defined with `serverless-sequelize-migrations` as a dependency. The bin gets installed 1 level up at the workspace root. Thus, it results in the following error:
```
/bin/sh: node_modules/.bin/sequelize: No such file or directory
Serverless: Error trying to create migration: 
Error: Command failed: node_modules/.bin/sequelize migration:create --name initialize
/bin/sh: node_modules/.bin/sequelize: No such file or directory
```