### PR TITLE
Fix password env variable to prevent falsey values breaking migrations

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ class SequelizeMigrations {
       error = "DB_NAME";
     } else if (!process.env.DB_USERNAME) {
       error = "DB_USERNAME";
-    } else if (!process.env.DB_PASSWORD) {
+    } else if (!process.env.hasOwnProperty('DB_PASSWORD')) {
       error = "DB_PASSWORD";
     }
 


### PR DESCRIPTION
Hey everyone,

Decided to make a PR to fix this given that it gave me a lot of trouble yesterday, the way it is current set up, a falsey value (ie false, 0, null, undefined) leads the plugin to believe the user didn't set up the DB_PASSWORD field. 

Changed this just for the DB_PASSWORD field because I don't think it's reasonable to have those values anywhere else, but we could apply that logic to all the fields to be consistent, up to you @manelferreira.

Thank you :)