### PR TITLE
Added support for SQL connection string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,4 +64,7 @@ jspm_packages/
 # Serverless directories
 .serverless/
 
+# Editor config
+.idea/
+
 # End of https://www.gitignore.io/api/node

--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ provider:
     DB_HOST: 'database_host'
     DB_PORT: 'database_port'
 ```
+or by using DB_CONNECTION_URL
+```
+provider:
+  environment:
+    DB_CONNECTION_URL: database_dialect://database_username:database_password@database_host:database_port/database_name`
+```
 Replace the variables with the information of your own database.
 
 Obs: This plugin does not have support to create the database itself.

--- a/handlers/migrationsHandler.js
+++ b/handlers/migrationsHandler.js
@@ -16,20 +16,12 @@ module.exports = class MigrationsHandler {
   }
 
   initSequelize() {
-    return new Sequelize(
-      this.database.NAME,
-      this.database.USERNAME,
-      this.database.PASSWORD,
-      {
-        dialect: this.database.DIALECT,
-        host: this.database.HOST,
-        port: this.database.PORT,
-        define: {
-          freezeTableName: true
-        },
-        logging: this.verbose
-      }
-    );
+    return new Sequelize(this.database.CONNECTION_URL, {
+      define: {
+        freezeTableName: true
+      },
+      logging: this.verbose
+    });
   }
 
   initUmzug() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-sequelize-migrations",
-  "version": "1.0.7",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -56,10 +56,11 @@ describe("Serverless sequelize migrations", () => {
       delete process.env.DB_NAME;
       delete process.env.DB_USERNAME;
       delete process.env.DB_PASSWORD;
+      delete process.env.DB_CONNECTION_URL;
       this.processStub.restore();
     });
 
-    context ("when some required property is missing", () => {
+    context("when some required property is missing", () => {
       it("fail if DB_DIALECT is missing", () => {
         this.serverless.service.provider.environment = {
           DB_HOST: "localhost",
@@ -70,9 +71,9 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
@@ -80,7 +81,7 @@ describe("Serverless sequelize migrations", () => {
         );
         sinon.assert.calledWith(process.exit, 1);
       });
-  
+
       it("fail if DB_HOST is missing", () => {
         this.serverless.service.provider.environment = {
           DB_DIALECT: "mysql",
@@ -91,9 +92,9 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
@@ -101,7 +102,7 @@ describe("Serverless sequelize migrations", () => {
         );
         sinon.assert.calledWith(process.exit, 1);
       });
-  
+
       it("fail if DB_PORT is missing", () => {
         this.serverless.service.provider.environment = {
           DB_DIALECT: "mysql",
@@ -112,9 +113,9 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
@@ -122,7 +123,7 @@ describe("Serverless sequelize migrations", () => {
         );
         sinon.assert.calledWith(process.exit, 1);
       });
-  
+
       it("fail if DB_NAME is missing", () => {
         this.serverless.service.provider.environment = {
           DB_DIALECT: "mysql",
@@ -133,9 +134,9 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
@@ -143,7 +144,7 @@ describe("Serverless sequelize migrations", () => {
         );
         sinon.assert.calledWith(process.exit, 1);
       });
-  
+
       it("fail if DB_USERNAME is missing", () => {
         this.serverless.service.provider.environment = {
           DB_DIALECT: "mysql",
@@ -154,9 +155,9 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
@@ -164,7 +165,7 @@ describe("Serverless sequelize migrations", () => {
         );
         sinon.assert.calledWith(process.exit, 1);
       });
-  
+
       it("fail if DB_PASSWORD is missing", () => {
         this.serverless.service.provider.environment = {
           DB_DIALECT: "mysql",
@@ -175,13 +176,31 @@ describe("Serverless sequelize migrations", () => {
         };
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         plugin.setUpDatabaseValues();
         sinon.assert.calledWith(
           logFunction,
           "Missing DB_PASSWORD in the environment variables"
+        );
+        sinon.assert.calledWith(process.exit, 1);
+      });
+
+      it("fail if DB_CONNECTION_URL is invalid", () => {
+        this.serverless.service.provider.environment = {
+          DB_CONNECTION_URL:
+            "invalid_dialect://username:password@localhost:3306/name"
+        };
+        const logFunction = sinon.spy();
+        this.serverless.cli.log = logFunction;
+
+        const plugin = new SlsSequelizeMigrations(this.serverless, {});
+
+        plugin.setUpDatabaseValues();
+        sinon.assert.calledWith(
+          logFunction,
+          "DB_CONNECTION_URL environment variable is not valid"
         );
         sinon.assert.calledWith(process.exit, 1);
       });
@@ -200,21 +219,16 @@ describe("Serverless sequelize migrations", () => {
               DB_PASSWORD: null
             };
             this.serverless.service.provider.environment = envDbData;
-      
+
             const logFunction = sinon.spy();
             this.serverless.cli.log = logFunction;
-      
+
             const plugin = new SlsSequelizeMigrations(this.serverless, {});
-      
+
             const database = plugin.setUpDatabaseValues();
-      
+
             expect(database).to.be.eql({
-              DIALECT: envDbData.DB_DIALECT,
-              HOST: envDbData.DB_HOST,
-              PORT: envDbData.DB_PORT,
-              NAME: envDbData.DB_NAME,
-              USERNAME: envDbData.DB_USERNAME,
-              PASSWORD: `${envDbData.DB_PASSWORD}`
+              CONNECTION_URL: `${envDbData.DB_DIALECT}://${envDbData.DB_USERNAME}:${envDbData.DB_PASSWORD}@${envDbData.DB_HOST}:${envDbData.DB_PORT}/${envDbData.DB_NAME}`
             });
           });
         });
@@ -227,24 +241,19 @@ describe("Serverless sequelize migrations", () => {
               DB_PORT: "3306",
               DB_NAME: "name",
               DB_USERNAME: "username",
-              DB_PASSWORD: ''
+              DB_PASSWORD: ""
             };
             this.serverless.service.provider.environment = envDbData;
-      
+
             const logFunction = sinon.spy();
             this.serverless.cli.log = logFunction;
-      
+
             const plugin = new SlsSequelizeMigrations(this.serverless, {});
-      
+
             const database = plugin.setUpDatabaseValues();
-      
+
             expect(database).to.be.eql({
-              DIALECT: envDbData.DB_DIALECT,
-              HOST: envDbData.DB_HOST,
-              PORT: envDbData.DB_PORT,
-              NAME: envDbData.DB_NAME,
-              USERNAME: envDbData.DB_USERNAME,
-              PASSWORD: `${envDbData.DB_PASSWORD}`
+              CONNECTION_URL: `${envDbData.DB_DIALECT}://${envDbData.DB_USERNAME}:${envDbData.DB_PASSWORD}@${envDbData.DB_HOST}:${envDbData.DB_PORT}/${envDbData.DB_NAME}`
             });
           });
         });
@@ -260,21 +269,16 @@ describe("Serverless sequelize migrations", () => {
           DB_PASSWORD: "password"
         };
         this.serverless.service.provider.environment = envDbData;
-  
+
         const logFunction = sinon.spy();
         this.serverless.cli.log = logFunction;
-  
+
         const plugin = new SlsSequelizeMigrations(this.serverless, {});
-  
+
         const database = plugin.setUpDatabaseValues();
-  
+
         expect(database).to.be.eql({
-          DIALECT: envDbData.DB_DIALECT,
-          HOST: envDbData.DB_HOST,
-          PORT: envDbData.DB_PORT,
-          NAME: envDbData.DB_NAME,
-          USERNAME: envDbData.DB_USERNAME,
-          PASSWORD: envDbData.DB_PASSWORD
+          CONNECTION_URL: `${envDbData.DB_DIALECT}://${envDbData.DB_USERNAME}:${envDbData.DB_PASSWORD}@${envDbData.DB_HOST}:${envDbData.DB_PORT}/${envDbData.DB_NAME}`
         });
       });
     });

--- a/test/migrationsHandler.js
+++ b/test/migrationsHandler.js
@@ -18,12 +18,7 @@ describe("Migrations Handler", () => {
           }
         };
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 
@@ -96,12 +91,7 @@ describe("Migrations Handler", () => {
 
       it("creates sequelize instance with success", () => {
         const database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
 
         const migrationsHandler = new MigrationsHandler(
@@ -111,13 +101,7 @@ describe("Migrations Handler", () => {
 
         const sequelize = migrationsHandler.initSequelize();
 
-        expect(sequelize.options.dialect).to.eq(database.DIALECT);
         expect(sequelize.options.define.freezeTableName).to.eq(true);
-        expect(sequelize.config.database).to.eq(database.NAME);
-        expect(sequelize.config.username).to.eq(database.USERNAME);
-        expect(sequelize.config.password).to.eq(database.PASSWORD);
-        expect(sequelize.config.host).to.eq(database.HOST);
-        expect(sequelize.config.port).to.eq(database.PORT);
       });
 
       it("fails if DB_DIALECT is missing", () => {
@@ -144,12 +128,7 @@ describe("Migrations Handler", () => {
         };
 
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 
@@ -210,12 +189,7 @@ describe("Migrations Handler", () => {
         };
 
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 
@@ -571,12 +545,7 @@ describe("Migrations Handler", () => {
         };
 
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 
@@ -876,12 +845,7 @@ describe("Migrations Handler", () => {
         };
 
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 
@@ -972,12 +936,7 @@ describe("Migrations Handler", () => {
         };
 
         this.database = {
-          DIALECT: "mysql",
-          HOST: "localhost",
-          PORT: "3306",
-          NAME: "name",
-          USERNAME: "username",
-          PASSWORD: "password"
+          CONNECTION_URL: "mysql://username:password@localhost:3306/name"
         };
       });
 

--- a/test/sequelizeCliHandler.js
+++ b/test/sequelizeCliHandler.js
@@ -9,10 +9,12 @@ describe("Sequelize CLI Handler", () => {
         cli: {
           log: sinon.spy()
         }
-      }
+      };
       this.serverless = serverless;
 
-      const execSyncStub = sinon.stub(childProcess, "execSync").returns("result");
+      const execSyncStub = sinon
+        .stub(childProcess, "execSync")
+        .returns("result");
       this.execSyncStub = execSyncStub;
 
       const bufferStub = sinon.stub(Buffer, "from").returns("cmdOutput");
@@ -23,16 +25,19 @@ describe("Sequelize CLI Handler", () => {
       this.execSyncStub.restore();
       this.bufferStub.restore();
     });
-  
+
     context("when specifying a migrations folder path", () => {
       it("create migration", () => {
         const customFolder = "./customFolder";
-    
-        const sequelizeCliHandler = new SequelizeCliHandler(this.serverless, customFolder);
-    
+
+        const sequelizeCliHandler = new SequelizeCliHandler(
+          this.serverless,
+          customFolder
+        );
+
         const migrationName = "name";
         sequelizeCliHandler.createMigration(migrationName);
-    
+
         sinon.assert.calledOnce(this.serverless.cli.log);
         sinon.assert.calledWith(this.bufferStub, "result", "base64");
         sinon.assert.calledWith(
@@ -41,14 +46,14 @@ describe("Sequelize CLI Handler", () => {
         );
       });
     });
-  
+
     context("when using the default migrations folder", () => {
-      it("create migration", () => {    
+      it("create migration", () => {
         const sequelizeCliHandler = new SequelizeCliHandler(this.serverless);
-    
+
         const migrationName = "name";
         sequelizeCliHandler.createMigration(migrationName);
-    
+
         sinon.assert.calledOnce(this.serverless.cli.log);
         sinon.assert.calledWith(this.bufferStub, "result", "base64");
         sinon.assert.calledWith(


### PR DESCRIPTION
When using AWS SSM some users would like to use DB_CONNECTION_URL instead of passing all DB parameters.

This feature has an Open Closed approach which means that users of the previous version will not have issues with the new version.

All tests are passing and code lint has no errors.