### PR TITLE
Add support for passing host through the CLI

### DIFF
--- a/index.js
+++ b/index.js
@@ -150,7 +150,7 @@ class SequelizeMigrations {
 
     const connectionProperties = {
       DIALECT: process.env.DB_DIALECT,
-      HOST: process.env.DB_HOST,
+      HOST: this.getDBHost(),
       PORT: process.env.DB_PORT,
       NAME: process.env.DB_NAME,
       USERNAME: process.env.DB_USERNAME,
@@ -165,12 +165,15 @@ class SequelizeMigrations {
       + `/${connectionProperties.NAME}`;
   }
 
+  getDBHost() {
+    return process.env.DB_HOST || this.options.host
+  }
   checkForMissingDatabaseConnectionIndividualProperties() {
     let missing = false;
-
+    
     if (!process.env.DB_DIALECT) {
       missing = "DB_DIALECT";
-    } else if (!process.env.DB_HOST) {
+    } else if (!this.getDBHost()) {
       missing = "DB_HOST";
     } else if (!process.env.DB_PORT) {
       missing = "DB_PORT";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-sequelize-migrations",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Hi,

Thanks for this extremely helpful plugin, saved me a lot of time!

I store the RDS host in the Cloudfront output, referencing this output during the first deployment will cause it to break since there is no Cloudformation stack, hence adding it to the DB_HOST environment variable of the provider is not a feasible option. Referencing it using Fn::GetAtt doesn't seem to work with the plugin either. 

While running migrations for AWS Aurora I trigger the migrations post a successful deploy, I have some custom code in place that allows us to fetch the host from the Cloudfront outputs, since this code executes post successful deployment the stack and the output exist for sure. 
I then pass the OutputValue as follows, 

```
npx serverless migrations up --host=<host-value>
```

This PR is to allow the plugin to accept the host through the cli for such use cases. 